### PR TITLE
fix: Seleccionar conversión en mobile

### DIFF
--- a/src/components/products/product-conversion-header.vue
+++ b/src/components/products/product-conversion-header.vue
@@ -112,6 +112,7 @@ export default {
         position: absolute;
         right: 15px;
         top: 20px;
+		z-index: 10;
 
         @media (min-width: 950px) {
             display: none !important;


### PR DESCRIPTION
**Description**
Permitir seleccionar una conversion cuando el resposive es mobile

**Acceptance Test**
none

**Implementation Notes**
none

**References**
https://www.notion.so/DESDE-EL-ECOMMERCE-CUANDO-INGRESAN-DESDE-UN-CELULAR-NO-PERMITE-SELECCIONAR-UNA-CONVERCION-7e98487ba0cd482594702794f41051d3

