### PR TITLE
feat: Permitir hacer un pedido con ecommerces extranjeros

### DIFF
--- a/src/components/order/new-address.vue
+++ b/src/components/order/new-address.vue
@@ -249,13 +249,13 @@ async function calculateShippingCost(locationId, location) {
 		if (error.data.message === 'PRICE_NOT_CONFIGURATION') {
 			this.$store.dispatch('setShippingCostError', true);
 			this.$store.dispatch('setNoShippingCost');
-			// this.showNotification(
-			// 	'No es posible hacer envios a ese destino.',
-			// 	'error',
-			// 	null,
-			// 	false,
-			// 	2000,
-			// );
+			this.showNotification(
+				'No es posible hacer envios a ese destino.',
+				'error',
+				null,
+				false,
+				2000,
+			);
 		}
 	}
 }

--- a/src/components/order/responsible-form.vue
+++ b/src/components/order/responsible-form.vue
@@ -187,11 +187,11 @@ function validateForm() {
 }
 
 function labelCountry() {
-	return getDeeper('company.country.countryCode')(this.user) === 'ECU' ? 'Cédula' : 'DNI';
+	return this.countryLabels.dni;
 }
 
 function labelError() {
-	return getDeeper('company.country.countryCode')(this.user) === 'ECU' ? 'El número de documento es requerido' : 'El DNI es requerido';
+	return `${this.countryLabels.dni} es requerido`;
 }
 
 function setResponsible(who) {

--- a/src/shared/countries.json
+++ b/src/shared/countries.json
@@ -1,14 +1,44 @@
 {
-    "PER": {
-        "department": "Departamento",
-        "district": "Distrito",
-        "dni": "dni",
-        "province": "Provincia"
-    },
-    "ECU": {
-        "department": "Provincia",
-        "dni": "Cédula",
-        "district": "Parroquia",
-        "province": "Ciudad"
-    }
+	"PER": {
+		"department": "Departamento",
+		"district": "Distrito",
+		"dni": "DNI",
+		"province": "Provincia"
+	},
+	"ECU": {
+		"department": "Provincia",
+		"dni": "Cédula",
+		"district": "Parroquia",
+		"province": "Ciudad"
+	},
+	"CHL": {
+		"department": "Región",
+		"district": "Comuna",
+		"dni": "RUT",
+		"province": "Provincia"
+	},
+	"ARG": {
+		"department": "Provincia",
+		"district": "Localidad",
+		"dni": "DNI",
+		"province": "Provincia"
+	},
+	"DOM": {
+		"department": "Provincia",
+		"district": "Municipio",
+		"dni": "Cédula",
+		"province": "Provincia"
+	},
+	"COL": {
+		"department": "Departamento",
+		"district": "Municipio",
+		"dni": "Cédula",
+		"province": "Departamento"
+	},
+	"BOL": {
+		"department": "Departamento",
+		"district": "Municipio",
+		"dni": "Cédula de Identidad",
+		"province": "Provincia"
+	}
 }


### PR DESCRIPTION
**Description**
En los ecommerce extranjeros no permite crear un pedido, validar si no son paises de ecuador o peru, igual nos debe de permitir la creacion del pedido

**Planning Estimate**
2

**References**
https://www.notion.so/DESDE-LA-TIENDA-ONLINE-PARA-CLIENTES-EXTRANJEROS-NO-PERMITE-GENERAR-LA-COMPRA-TANTO-DE-ENVIO-A-DOMIC-0d28a8f9209b4fee88c459120dabcbbd
