### PR TITLE
fix: No permite crear un pedido con producto sin stock

### DIFF
--- a/src/components/order/summary-order.vue
+++ b/src/components/order/summary-order.vue
@@ -36,13 +36,17 @@
 			<div v-if="stepOne">
 				<app-button
 					data-cy="make-order"
-					:disabled="!allStock"
+					:disabled="!allStock && !$allowOrderStockNegative"
 					:action="`Hacer pedido ${getCurrencySymbol}. ${listenerPriceOrder}`"
 					class="btn-order"
 					:background="globalColors.primary"
 					@click="goToMakeOrder"
 				/>
-				<span v-if="isNoOrderPrice && orderPrice" class="text-min-order">El monto mínimo para realizar un pedido es de {{getCurrencySymbol}} {{minOrderPrice}}, pero tu pedido actual es de {{getCurrencySymbol}} {{listenerPriceOrder}}.</span>
+				<span v-if="isNoOrderPrice && orderPrice" class="text-min-order"
+					>El monto mínimo para realizar un pedido es de
+					{{ getCurrencySymbol }} {{ minOrderPrice }}, pero tu pedido actual es
+					de {{ getCurrencySymbol }} {{ listenerPriceOrder }}.</span
+				>
 			</div>
 			<app-button
 				data-cy="go-pay"
@@ -75,7 +79,7 @@ import { creditCard } from '@/shared/enums/wayPayment';
 
 function total() {
 	const totalBuyWithShipp =
-		(this.getTotalToBuy - this.discount) + this.getShippingCost;
+		this.getTotalToBuy - this.discount + this.getShippingCost;
 	const newTotal = Number(totalBuyWithShipp.toFixed(2));
 	this.$store.commit('SET_TOTAL_BUY_SHIPP', newTotal);
 	return newTotal;
@@ -225,10 +229,12 @@ export default {
 		listenerPriceOrder,
 		styleBtnMobile,
 		orderPrice() {
-			const ecommerce = JSON.parse(localStorage.getItem('ecommerce::ecommerce-data')) || null;
+			const ecommerce =
+				JSON.parse(localStorage.getItem('ecommerce::ecommerce-data')) || null;
 			if (ecommerce) {
 				this.minOrderPrice = ecommerce.settings.minOrderPrice;
-				const isMinOrderPrice = this.minOrderPrice > Number(this.listenerPriceOrder);
+				const isMinOrderPrice =
+					this.minOrderPrice > Number(this.listenerPriceOrder);
 				return isMinOrderPrice;
 			}
 			return false;

--- a/src/components/order/summary-order.vue
+++ b/src/components/order/summary-order.vue
@@ -118,7 +118,7 @@ function stepTwo() {
 }
 
 function goToMakeOrder() {
-	if (!this.validateStock) {
+	if (!this.validateStock && !this.$allowOrderStockNegative) {
 		this.showGenericError(this.message);
 		return;
 	}


### PR DESCRIPTION
**Description**
si queremos crear un pedido con productos sin stock no nos permite crear apesar de tener el flag allowOrderStockNegative activo
![Image](https://github.com/user-attachments/assets/5b52deb2-54b5-4ac0-9fbc-24e4f84fc942)

https://deploy-preview-1405--minimarketcasamarket.netlify.app/

**References**
https://www.notion.so/NO-PERMITE-GENERAR-PEDIDO-DE-LA-TIENDA-ONLINE-1bb8f8caa2a880958c8fc4d2df5e4ade
