### PR TITLE
Validar mostrar und principal o conversiones al agregar prod al carrito

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1029,5 +1029,4 @@ input.app-input::-webkit-input-placeholder {
 		bottom: -10px;
 	}
 }
-
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1029,4 +1029,5 @@ input.app-input::-webkit-input-placeholder {
 		bottom: -10px;
 	}
 }
+
 </style>

--- a/src/components/products/product-card.vue
+++ b/src/components/products/product-card.vue
@@ -533,7 +533,8 @@ export default {
 		selectUnitCar() {
 			if (
 				this.product.conversions &&
-				typeof this.product.conversions === 'object'
+				typeof this.product.conversions === 'object' &&
+				this.$flagShowBaseUnit !== 2
 			) {
 				const { priceList } = this.product;
 				const ecommerce =


### PR DESCRIPTION
El caso del cliente es que cuando usuario quiere agregar un producto al carrito que tiene conversiones le da a escoger que conversion va a querer, apesar de tener la configuracion de tomar directamente la unidad por defecto 
Se hizo la correción para validar correctamente el uso del flag en el ecommerce y ya no le de la opcion de escoger la unidad al usuario

https://www.notion.so/3059-Revisar-al-comprar-un-producto-compuesto-y-el-ocultar-conversion-TIENDA-ONLINE-2278f8caa2a88017a1a7f8b425ca2e07?source=copy_link