### PR TITLE
fix: Validar mostrar las conversiones segun parametros globales

### DIFF
--- a/src/components/products/product-card.vue
+++ b/src/components/products/product-card.vue
@@ -548,19 +548,23 @@ export default {
 						? priceList[defaultIdPiceList].units
 						: null;
 				this.showViewProduct = false;
-				this.conversionsProducts = Object.keys(this.product.conversions).map(
-					key => ({
-						id: key,
-						...priceListUnits[key],
-						...this.product.conversions[key],
-					}),
-				);
-				if (this.conversionsProducts.length) {
+				if (this.$flagShowBaseUnit !== 2) {
+					this.conversionsProducts = Object.keys(this.product.conversions).map(
+						key => ({
+							id: key,
+							...priceListUnits[key],
+							...this.product.conversions[key],
+						}),
+					);
+				}
+				if (this.$flagShowBaseUnit !== 1) {
 					this.conversionsProducts.unshift(
 						this.product.unitDefault || this.product.unit,
 					);
-				} else {
-					this.addToCar();
+				}
+
+				if (this.conversionsProducts.length === 1) {
+					this.addToCar(this.conversionsProducts[0]);
 				}
 				this.addQuantity = !this.addQuantity;
 			} else {
@@ -574,6 +578,7 @@ export default {
 		},
 		closeViewProduct() {
 			this.showViewProduct = true;
+			this.addQuantity = true;
 		},
 	},
 	created,

--- a/src/pages/page-detail-product.vue
+++ b/src/pages/page-detail-product.vue
@@ -146,9 +146,10 @@ async function loadProduct() {
 			const { conversions } = this.product;
 			const stock = helper.stockProductByType(this.product);
 			const firstConversion = Object.keys(conversions || {})[0];
-			const stockAvaible = firstConversion
-				? parseInt(stock / firstConversion.quantity, 10)
-				: stock;
+			const stockAvaible =
+				firstConversion && stock !== Infinity
+					? parseInt(stock / firstConversion.quantity, 10)
+					: stock;
 			this.stockAvaible = stockAvaible;
 			this.$store.dispatch('setStock', this.stockAvaible);
 		}


### PR DESCRIPTION
Segun la configuracion por compañia, se deberan mostrar las conversiones y ocultar la unidad principal
https://www.notion.so/EN-LA-TIENDA-ONLINE-EN-LAS-VISTA-PREVIA-SE-SIGUEN-MOSTRANDO-LA-UNIDAD-BASE-CUANDO-SE-CONFIGURO-QUE-S-25a8f8caa2a880fe9572e28142670c98
<img width="528" height="99" alt="image" src="https://github.com/user-attachments/assets/728b2fbd-4e76-4fe0-9439-0d3e4caa3d7b" />
