### PR TITLE
fix: Validar los usuarios al registar o iniciar sesion

### DIFF
--- a/src/http/interceptors-factory.js
+++ b/src/http/interceptors-factory.js
@@ -3,7 +3,7 @@ export default function createInterceptors(store) {
 		store.dispatch('clearUser');
 		store.dispatch('DEFAULT_USER');
 		store.dispatch('SET_DEFAULT_VALUES');
-		localStorage.clear();
+		// localStorage.clear();
 	}
 
 	return {

--- a/src/pages/page-login.vue
+++ b/src/pages/page-login.vue
@@ -152,8 +152,6 @@ async function initSession() {
 		const { data: response } = await this.$httpSales.post('signin/auth', body, {
 			headers,
 		});
-		console.log('response', response);
-		console.log('this', this);
 		if (response.code === 1008) {
 			this.showGenericError('Correo o password incorrecto.', 50000);
 		} else if (response.data) {
@@ -172,6 +170,10 @@ async function initSession() {
 			this.showNotification(
 				'Su cuenta no está activada. Le hemos enviado un correo para que lo pueda hacer',
 				'accent',
+			);
+		} else if (err.data && err.data.code === 1008) {
+			this.showGenericError(
+				'La contraseña ingresada no es correcta. Si has olvidado tu contraseña, puedes recuperarla.',
 			);
 		} else {
 			this.showGenericError();

--- a/src/pages/page-register.vue
+++ b/src/pages/page-register.vue
@@ -151,6 +151,10 @@ async function createAccount() {
 			) {
 				this.showGenericError('El email ya ha sido registrado.', 50000);
 			}
+		} else if (err.data && err.data.code === 1008) {
+			this.showGenericError(
+				'Tu cuenta ya está registrada. ¡Inicia sesión para continuar!',
+			);
 		} else if (err.status === 500) {
 			this.showGenericError();
 		}

--- a/src/store/asyncActions.js
+++ b/src/store/asyncActions.js
@@ -233,7 +233,6 @@ const asyncActions = {
 		const aclCode = ACL_COMPANY_CODE;
 		const url = `companies/${aclCode}/acl`;
 		const { data: res } = await context.$httpSales.get(url);
-		console.log('res', res);
 		context.setLocalData(`${STORAGE_USER_KEY}::currency-default`, res.currencyDefault);
 		context.setLocalData(`${STORAGE_USER_KEY}::country`, res.country.countryCode);
 		commit('SET_CURRENCY_DEFAULT', res.currencyDefault);


### PR DESCRIPTION
CUANDO SE INTENTA REGISTRAR O INICIAR SESION, CON UNA CUENTA CREADA PERO CON LA CONTRASENA INCORRECTA, NO DA ERROR, VALIDAR EL MENSAJE DE ERROR PARA QUE EL USUARIO RECUPERE LA CONTRASENA

https://www.notion.so/Error-al-registrarse-desde-el-ecommerce-2808f8caa2a880ea961ce1212bff9d89