### PR TITLE
fix: Remover punto en 4 en libro de reclamaciones

### DIFF
--- a/src/pages/page-reclamaciones.vue
+++ b/src/pages/page-reclamaciones.vue
@@ -149,7 +149,7 @@
 					v-model="reclamation.claimOrder"
 				></text-area>
 			</div>
-			<div class="section">
+			<!-- <div class="section">
 				<h4>4. Observaciones y acciones adoptadas por el proveedor</h4>
 				<label>
 					Fecha de comunicación de la respuesta
@@ -164,7 +164,7 @@
 						v-model="reclamation.answerDescription"
 					></text-area>
 				</label>
-			</div>
+			</div> -->
 			<button
 				type="button"
 				:disabled="$v.$invalid"
@@ -238,8 +238,8 @@ async function reclamationAction() {
 function validations() {
 	return {
 		reclamation: {
-			answerDate: { required },
-			answerDescription: { required },
+			// answerDate: { required },
+			// answerDescription: { required },
 			claimDetail: { required },
 			claimDate: { required },
 			claimOrder: { required },
@@ -277,8 +277,8 @@ function validations() {
 function data() {
 	return {
 		reclamation: {
-			answerDate: '',
-			answerDescription: '',
+			// answerDate: '',
+			// answerDescription: '',
 			claimDetail: '',
 			claimDate: '',
 			claimOrder: '',


### PR DESCRIPTION
fix: Remover punto en 4 en libro de reclamaciones

Del formulario del libro de reclamaciones se removio los dos campos del punto 4.
Para completar el formulario exitosamente sin los campos primero se necesita que backend no pida como requeridos dichos campos `answerDescription` y `answerDate`

/claim-book

https://www.notion.so/En-la-pagina-online-en-la-opcion-de-libro-de-reclamaciones-el-punto-de-Observaciones-y-acciones-ado-3298f8caa2a880ccb57ac9793225a64e?source=copy_link
