### PR TITLE
fix: corregir validación de conversión de stock y multiplicación en decremento de carrito

### DIFF
--- a/src/components/products/product-card.vue
+++ b/src/components/products/product-card.vue
@@ -297,10 +297,26 @@ function addToCar(unit, show) {
 					? unitList.price
 					: this.product.priceDiscount * (unit.quantity || 1);
 		}
-		const { stock, stockWarehouse, stockComposite } = productSelected;
-		const finalStock = helper.isComposed(productSelected)
-			? stockComposite
-			: stockWarehouse || stock;
+        const { stock, stockWarehouse, stockComposite } = productSelected;
+        // Obtener el flag que indica si se debe usar la unidad base
+        let flagShowBaseUnit = 0;
+        if (this.getCommerceData && this.getCommerceData.company && this.getCommerceData.company.settings) {
+          flagShowBaseUnit = this.getCommerceData.company.settings.flagShowBaseUnit;
+        }
+        // Calcular el stock disponible según el flag
+        let finalStock;
+        if (flagShowBaseUnit === 1) {
+          // Usar la misma lógica que muestra el detalle del producto
+          const rawStock = stockProductByType(productSelected);
+          const firstConversion = Object.keys(productSelected.conversions || {})[0];
+          finalStock = (firstConversion && rawStock !== Infinity)
+            ? parseInt(rawStock / productSelected.conversions[firstConversion].quantity, 10)
+            : rawStock;
+        } else if (helper.isComposed(productSelected)) {
+          finalStock = stockComposite;
+        } else {
+          finalStock = stockWarehouse || stock;
+        }
 		const validate =
 			finalStock >= this.quantityAddProduct || this.$allowOrderStockNegative;
 		const quantity = validate ? this.quantityAddProduct : finalStock;

--- a/src/components/products/product-in-car.vue
+++ b/src/components/products/product-in-car.vue
@@ -178,7 +178,6 @@ function inputQuantity(value) {
 function clickQuantity(val) {
 	let { quantity } = this.product;
 	const { unit } = this.product;
-	const conversionQuantity = this.getConversionQuantity();
 	const realStock = this.stockProductByType();
 	if (val) {
 		quantity += val === 'more' ? 1 : -1;
@@ -200,11 +199,7 @@ function clickQuantity(val) {
 		this.$flagShowBaseUnit === 1
 			? this.product.priceDiscount
 			: this.product.priceDiscountOrigin;
-	if (
-		realStock < quantity ||
-		this.quantityStock * conversionQuantity >
-			helper.stockProductByType(this.product)
-	) {
+	if (realStock < quantity) {
 		this.showNotification(
 			`El producto ${this.product.name} no cuenta con más stock en la presentación: ${unit.name}.`,
 			'warning',


### PR DESCRIPTION
## Issue Pull Request Template
**Related Issue(s)**
_Issues:  #1462_
_Notion: [Notion](https://app.notion.com/p/ERROR-EN-LA-TIENDA-ONLINE-AL-AGREGAR-PRODUCTOS-Y-GENERAR-EL-PEDIDO-3708f8caa2a880b48938c321f23b60e3)_

**Acceptance Test(s)**
* **Caso 1: Disminución permitida en carrito**
    * Al estar en el carrito de compras e intentar disminuir la cantidad del producto con el botón (`-`), el sistema decrementa correctamente el valor en lugar de bloquear la acción.
* **Caso 2: Control riguroso de Stock con Flag de Conversión**
    * Al modificar o incrementar cantidades desde la pantalla inicial, el sistema valida el stock correctamente considerando la unidad de conversión si el flag está activo. Si el flag está inactivo, el flujo continúa de manera normal sin afectar el comportamiento estándar.

**Implementation Notes**
Para solucionar los dos errores reportados se realizaron los siguientes ajustes en los componentes afectados:

1. **Validación de conversión en Pantalla Inicial (`product-card.vue`):** 
   Se detectó que la lógica de selección de producto no consideraba la equivalencia cuando el flag de conversión estaba activo. Se encapsuló esta validación para que aplique **únicamente** cuando dicho flag está activo y en `1`. Si no se cumple esta condición, el sistema ejecuta el flujo de validación de stock normal, evitando romper el comportamiento por defecto de otros productos.

2. **Error al disminuir cantidad en Carrito (`product-in-car.vue`):** 
   Se identificó una multiplicación mal ejecutada en la lógica del componente que calculaba de forma errónea el nuevo límite al disminuir la cantidad, lo que provocaba que la acción se bloqueara por completo. Se corrigió la operación matemática para permitir el decremento natural del stock en el carrito.

**Related Pull Request(s)**
_"N/A"_