### PR TITLE
Fix: solución seleccionar presentaciones de un producto

### DIFF
--- a/src/components/products/product-conversions.vue
+++ b/src/components/products/product-conversions.vue
@@ -37,33 +37,46 @@ import AppSelect from '@/components/shared/inputs/app-select';
 import { mapGetters } from 'vuex';
 import { setNewProperty, map } from '@/shared/lib';
 
-function conversionsChanges(conversions) {
-	const ecommerce = JSON.parse(
-				localStorage.getItem('ecommerce::ecommerce-data'),
-			);
-	const flagShowBaseUnit = ecommerce.company.settings.flagShowBaseUnit;
+function conversionsChanges() {
 	let conversionsFormatted = [];
-	if (conversions) {
+	if (this.conversions) {
 		conversionsFormatted = map(
-			k => setNewProperty('id', Number(k))(conversions[k]),
-			Object.keys(conversions),
+			k => setNewProperty('id', Number(k))(this.conversions[k]),
+			Object.keys(this.conversions),
 		);
 	}
-	this.conversionsComputed = [].concat(this.defaultUnit, conversionsFormatted);
-	this.conversionsComputed = this.conversionsComputed.map((p, index) => {
+	const defaultUnitInConversions = conversionsFormatted.find(
+		c => c.id === (this.defaultUnit && this.defaultUnit.id),
+	);
+	if (this.defaultUnit && !defaultUnitInConversions) {
+		this.baseUnit = this.defaultUnit;
+	}
+	let list = [];
+	if (this.baseUnit) {
+		list.push(this.baseUnit);
+	}
+	conversionsFormatted.forEach(c => {
+		if (!this.baseUnit || c.id !== this.baseUnit.id) {
+			list.push(c);
+		}
+	});
+	list = list.map(p => {
 		const newP = { ...p };
-		newP.isSelected = index === 0;
+		newP.isSelected = this.defaultUnit && p.id === this.defaultUnit.id;
 		return newP;
 	});
-	if (flagShowBaseUnit === 1) {
-		this.conversionsComputed = this.conversionsComputed.filter(
-			p => p.id !== this.defaultUnit.id,
-		);
-	} else if (flagShowBaseUnit === 2) {
-		this.conversionsComputed = this.conversionsComputed.filter(
-			p => p.id === this.defaultUnit.id,
-		);
+	const ecommerce = JSON.parse(
+		localStorage.getItem('ecommerce::ecommerce-data'),
+	);
+	const flagShowBaseUnit = ecommerce && ecommerce.company && ecommerce.company.settings
+		? ecommerce.company.settings.flagShowBaseUnit
+		: null;
+	if (flagShowBaseUnit === 1 && this.baseUnit) {
+		list = list.filter(p => p.id !== this.baseUnit.id);
+	} else if (flagShowBaseUnit === 2 && this.baseUnit) {
+		list = list.filter(p => p.id === this.baseUnit.id);
 	}
+	this.conversionsComputed = list;
 }
 
 function selectedConversion(item) {
@@ -79,6 +92,7 @@ function data() {
 	return {
 		conversionSelected: null,
 		conversionsComputed: [],
+		baseUnit: null,
 	};
 }
 
@@ -112,6 +126,10 @@ export default {
 	},
 	watch: {
 		conversions: {
+			deep: true,
+			handler: conversionsChanges,
+		},
+		defaultUnit: {
 			deep: true,
 			handler: conversionsChanges,
 		},


### PR DESCRIPTION
## Issue Pull Request Template
**Related Issue(s)**
* Notion: https://app.notion.com/p/En-la-tienda-online-en-la-parte-de-seleccionar-presentaciones-de-un-producto-una-vez-seleccionado--3938f8caa2a880a780f4cdd54e79b689
* Issue: #1465 

**Acceptance Test(s)**

- [ ] Al ingresar al detalle del producto, se deben listar visualmente todas las presentaciones disponibles.
- [ ] Al seleccionar una presentación, la lista debe permanecer visible y reflejar el estado seleccionado de forma clara.
- [ ] El flujo visual no debe confundir al usuario ni alterar la lógica interna de selección existente.

**Implementation Notes**

En este PR se mejoró la interfaz de usuario en el componente de conversiones de productos.

- UI/UX: Se modificó el comportamiento visual para que la lista de presentaciones se mantenga visible de forma consistente después de que el usuario realiza una selección, evitando cambios bruscos que puedan causar confusión.
- Lógica: No se alteró la lógica de negocio ni el flujo interno de selección; los cambios son estrictamente a nivel de persistencia visual en el renderizado del componente.

**Related Pull Request(s)**
"N/A"
